### PR TITLE
MBS-8145: Fix content item repository core test

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1248,7 +1248,7 @@ if (defined( 'GAME_MOODLE_401')) {
         $type->name = preg_replace('/.*type=/', '', $type->type);
         $type->title = get_string('pluginname', 'game').' - '.get_string('game_'.$kind, 'game');
         $type->link = new moodle_url('/course/modedit.php',
-            array('add' => 'game', 'return' => 0, 'type' => $kind, 'course' => $course->id));
+            array('add' => 'game', 'return' => 0, 'type' => $kind, 'course' => $course->id, 'id' => $course->id));
         $type->help = '';
         if (empty($type->help) && !empty($type->name) &&
             get_string_manager()->string_exists('help' . $type->name, 'game')) {


### PR DESCRIPTION
Currently the moodle core test `core_course\content_item_readonly_repository_test::test_find_all_for_course` fails because of mod_game.

This PR fixes that.