### PR TITLE
Fix url decoding

### DIFF
--- a/backup/moodle2/restore_game_activity_task.class.php
+++ b/backup/moodle2/restore_game_activity_task.class.php
@@ -67,7 +67,9 @@ class restore_game_activity_task extends restore_activity_task {
      * to the activity to be executed by the link decoder
      */
     public static function define_decode_rules() {
-        $rules = array();
+        $rules = [];
+        $rules[] = new restore_decode_rule('GAMEINDEX', '/mod/game/index.php?id=$1', 'course');
+        $rules[] = new restore_decode_rule('GAMEVIEWBYID', '/mod/game/view.php?id=$1', 'course_module');
 
         return $rules;
     }


### PR DESCRIPTION
I noticed that the `define_decode_rules` was not using any rule to go with the encoding `encode_content_links`, so the backup-restore process was ending up with broken urls.