### PR TITLE
fixing syntax errors retrived during unit tests

### DIFF
--- a/bookquiz/questions.php
+++ b/bookquiz/questions.php
@@ -137,7 +137,7 @@ function game_bookquiz_save( $gameid, $bookid, $ids, $form) {
 
     $questions = $recids = [];
     if (($recs = $DB->get_records( 'game_bookquiz_questions',
-        [ 'gameid' => $gameid), '', 'id,chapterid,questioncategoryid']) != false) {
+        [ 'gameid' => $gameid], '', 'id,chapterid,questioncategoryid')) != false) {
         foreach ($recs as $rec) {
             $questions[$rec->chapterid] = $rec->questioncategoryid;
             $recids[$rec->chapterid] = $rec->id;

--- a/report/overview/report.php
+++ b/report/overview/report.php
@@ -486,7 +486,7 @@ class game_report extends game_default_report {
                                     userdate($attempt->timefinish, $strtimeformat).'</a>',
                                 empty($attempt->attempt) ? '-' : (
                                     empty($attempt->timefinish) ? get_string('unfinished', 'game') : format_time(
-                                    $attempt->duration)];
+                                    $attempt->duration))];
                     } else {
                         $row = [ fullname($attempt),
                                 empty($attempt->attempt) ? '-' : userdate($attempt->timestart, $strtimeformat),

--- a/sudoku/class.Sudoku.php
+++ b/sudoku/class.Sudoku.php
@@ -839,7 +839,7 @@ class s extends rcs {
      *
      * @var array
      */
-    protected $thecouplingorder = [ 1 => array[5, 6, 8, 9],
+    protected $thecouplingorder = array ( 1 => [5, 6, 8, 9],
         2 => [4, 6, 7, 9],
         3 => [4, 5, 7, 8],
         4 => [2, 3, 8, 9],
@@ -847,7 +847,7 @@ class s extends rcs {
         6 => [1, 2, 7, 8],
         7 => [2, 3, 5, 6],
         8 => [1, 3, 4, 6],
-        9 => [1, 2, 4, 5]];
+        9 => [1, 2, 4, 5]);
 
     /**
      * Constructor

--- a/tabs.php
+++ b/tabs.php
@@ -41,7 +41,7 @@ $context = game_get_context_module_instance( $cm->id);
 $tabs = [];
 $row = [];
 $inactive = [];
-$activated = []);
+$activated = [];
 
 global $USER;
 

--- a/tests/generator_testcase.php
+++ b/tests/generator_testcase.php
@@ -59,7 +59,7 @@ class mod_game_generator_testcase extends advanced_testcase {
 
         $params = ['course' => $course->id, 'name' => 'Another game', 'kind' => 'hangman'];
         $game = $this->getDataGenerator()->create_module('game', $params);
-        $records = $DB->get_records('game', ['course' => $course->id), 'id'];
+        $records = $DB->get_records('game', ['course' => $course->id], 'id');
         $this->assertEquals(2, count($records));
         $this->assertEquals('Another game', $records[$game->id]->name);
     }
@@ -90,7 +90,7 @@ class mod_game_generator_testcase extends advanced_testcase {
         $game = $this->getDataGenerator()->create_module('game',
             ['course' => $course, 'gamekind' => 'cross', 'name' => 'cross',
             'sourcemodule' => 'glossary', 'glossaryid' => $glossary->id]);
-        $records = $DB->get_records('game', ['course' => $course->id), 'id'];
+        $records = $DB->get_records('game', ['course' => $course->id], 'id');
         $this->assertEquals(1, count($records));
         $this->assertTrue(array_key_exists($game->id, $records));
         $cm = get_coursemodule_from_instance('game', $game->id, $course->id);


### PR DESCRIPTION
Hi,

There were issues during the PHP unit tests and I had to fix these lines of code. Here's an error sample I received . 

```
Parse error: syntax error, unexpected ')', expecting ']' in /var/www/html/mod/game/tests/generator_testcase.php on line 62
Errors parsing /var/www/html/mod/game/tests/generator_testcase.php
```

Thanks,
Pramith.